### PR TITLE
Update IdPs/SPs from SAML metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem 'mysql2'
 gem 'slim'
 gem 'terser'
 
+gem 'nokogiri'
+gem 'xmldsig'
+
 gem 'accession'
 gem 'activerecord-session_store'
 gem 'implicit-schema'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,6 +452,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (4.0.0)
+    xmldsig (0.6.6)
+      nokogiri (>= 1.6.8, < 2.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.13)
@@ -487,6 +489,7 @@ DEPENDENCIES
   launchy
   lograge
   mysql2
+  nokogiri
   pry
   puma
   rack-test
@@ -517,6 +520,7 @@ DEPENDENCIES
   torba-rails
   valhammer
   webmock
+  xmldsig
 
 BUNDLED WITH
    2.3.19

--- a/app/jobs/concerns/get_saml_metadata.rb
+++ b/app/jobs/concerns/get_saml_metadata.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module GetSAMLMetadata
+  SAML_NAMESPACES = {
+    'xmlns' => 'urn:oasis:names:tc:SAML:2.0:metadata',
+    'xmlns:md' => 'urn:oasis:names:tc:SAML:2.0:metadata',
+    'xmlns:saml' => 'urn:oasis:names:tc:SAML:2.0:assertion',
+    'xmlns:idpdisc' => 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol',
+    'xmlns:mdrpi' => 'urn:oasis:names:tc:SAML:metadata:rpi',
+    'xmlns:mdui' => 'urn:oasis:names:tc:SAML:metadata:ui',
+    'xmlns:mdattr' => 'urn:oasis:names:tc:SAML:metadata:attribute',
+    'xmlns:shibmd' => 'urn:mace:shibboleth:metadata:1.0',
+    'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
+    'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+    'xmlns:fed' => 'http://docs.oasis-open.org/wsfed/federation/200706',
+    'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706',
+    'xmlns:remd' => 'http://refeds.org/metadata'
+  }.freeze
+
+  def document(source, cert)
+    doc = Nokogiri::XML.parse(retrieve(source))
+
+    verify_signature(doc, cert) if cert
+
+    doc
+  end
+
+  def retrieve(source_url)
+    url = URI.parse(source_url)
+    response = perform_http_client_request(url)
+
+    return response.body if response.is_a?(Net::HTTPSuccess)
+
+    raise("Unable to retrieve metadata from #{source_url} (#{response.code} #{response.message})")
+  end
+
+  def perform_http_client_request(url)
+    request = Net::HTTP::Get.new(url)
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = (url.scheme == 'https')
+    http.read_timeout = 600
+    request['Accept'] = 'application/samlmetadata+xml'
+
+    http.request(request)
+  end
+
+  def verify_signature(doc, cert)
+    return if Xmldsig::SignedDocument.new(doc).validate(cert)
+
+    raise("Invalid signature for metadata from #{source}")
+  end
+
+  def xpath(node, path)
+    node.xpath(path, SAML_NAMESPACES)
+  end
+
+  def xpath_at(node, path)
+    xpath(node, path)[0]
+  end
+
+  def attr_val(node, attr)
+    node.attributes[attr]&.value
+  end
+end

--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -18,7 +18,7 @@ class UpdateFromFederationRegistry
 
   def sync_organizations
     fr_objects(:organizations, 'organizations').flat_map do |org_data|
-      fix_organization_identifier(org_data)
+      fix_organization_identifier(org_data) if saml_metadata_sync_enabled?
       org = sync_organization(org_data)
       idps = sync_identity_providers(org) unless saml_metadata_sync_enabled?
       sps = sync_service_providers(org) unless saml_metadata_sync_enabled?

--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -20,11 +20,15 @@ class UpdateFromFederationRegistry
     fr_objects(:organizations, 'organizations').flat_map do |org_data|
       fix_organization_identifier(org_data)
       org = sync_organization(org_data)
-      idps = sync_identity_providers(org)
-      sps = sync_service_providers(org)
+      idps = sync_identity_providers(org) unless saml_metadata_sync_enabled?
+      sps = sync_service_providers(org) unless saml_metadata_sync_enabled?
 
       [org, *idps, *sps].compact
     end
+  end
+
+  def saml_metadata_sync_enabled?
+    Rails.application.config.reporting_service.saml_metadata[:metadata_url]
   end
 
   def sync_identity_providers(org)

--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -106,7 +106,7 @@ class UpdateFromFederationRegistry
   def clean(touched_objs)
     grouped_objs = touched_objs.group_by(&:class)
     # Don't clean up most objects since some might be from the SAML service
-    #klasses = [
+    # klasses = [
     #  IdentityProviderSAMLAttribute,
     #  ServiceProviderSAMLAttribute,
     #  IdentityProvider,

--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -105,14 +105,16 @@ class UpdateFromFederationRegistry
 
   def clean(touched_objs)
     grouped_objs = touched_objs.group_by(&:class)
-    klasses = [
-      IdentityProviderSAMLAttribute,
-      ServiceProviderSAMLAttribute,
-      IdentityProvider,
-      ServiceProvider,
-      SAMLAttribute,
-      Organization
-    ]
+    # Don't clean up most objects since some might be from the SAML service
+    #klasses = [
+    #  IdentityProviderSAMLAttribute,
+    #  ServiceProviderSAMLAttribute,
+    #  IdentityProvider,
+    #  ServiceProvider,
+    #  SAMLAttribute,
+    #  Organization
+    #]
+    klasses = [SAMLAttribute]
     klasses.each do |klass|
       objs = grouped_objs.fetch(klass, [])
       klass.where.not(id: objs.map(&:id)).destroy_all

--- a/app/jobs/update_from_federation_registry.rb
+++ b/app/jobs/update_from_federation_registry.rb
@@ -57,7 +57,7 @@ class UpdateFromFederationRegistry
 
   def sync_organization(org_data)
     identifier = org_identifier(org_data[:id])
-    sync_object(Organization, org_data, { identifier: }, name: org_data[:display_name])
+    sync_object(Organization, org_data, { identifier: }, name: org_data[:display_name], domain: org_data[:domain])
   end
 
   def sync_saml_entity(org, klass, obj_data)

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -43,7 +43,7 @@ class UpdateFromSAMLMetadata
     process_sp(sp_node, entity_id, org, reg_date) if sp_node
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def process_org(node)
     org_domain_node = xpath_at(node, './md:OrganizationName')
     org_name_node = xpath_at(node, "./md:OrganizationDisplayName[@xml:lang='en']") ||
@@ -55,15 +55,18 @@ class UpdateFromSAMLMetadata
     org_name = org_name_node.content.strip
 
     org = Organization.find_or_initialize_by(domain: org_domain)
-    org_attrs = { name: org_name }
 
+    # only update the organisation if newly created or still bearing original temporary ID (not updated from FR yet)
+    return org unless org.id.nil? || org.identifier.start_with?('metadata_')
+
+    org_attrs = { name: org_name }
     org_attrs[:identifier] = org_identifier_from_name(org_domain) if org.id.nil?
 
     org.update!(org_attrs)
 
     org
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   def process_idp(node, entity_id, org, reg_date)
     idp = IdentityProvider.find_or_initialize_by(entity_id: )

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -3,7 +3,7 @@
 
 require 'net/http'
 
-class UpdateFromSAMLService
+class UpdateFromSAMLMetadata
   include GetSAMLMetadata
 
   def self.perform
@@ -136,7 +136,7 @@ class UpdateFromSAMLService
   end
 
   def configuration
-    Rails.application.config.reporting_service.saml_service
+    Rails.application.config.reporting_service.saml_metadata
   end
 
   def org_identifier(name)

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -43,9 +43,11 @@ class UpdateFromSAMLMetadata
     process_sp(sp_node, entity_id, org, reg_date) if sp_node
   end
 
+  # rubocop:disable Metrics/MethodLength
   def process_org(node)
     org_id_node = xpath_at(node, './md:OrganizationName')
-    org_name_node = xpath_at(node, './md:OrganizationDisplayName')
+    org_name_node = xpath_at(node, "./md:OrganizationDisplayName[@xml:lang='en']") ||
+                    xpath_at(node, "./md:OrganizationDisplayName[starts-with(@xml:lang, 'en')]")
 
     return nil unless org_id_node && org_name_node
 
@@ -61,11 +63,13 @@ class UpdateFromSAMLMetadata
 
     org
   end
+  # rubocop:enable Metrics/MethodLength
 
   def process_idp(node, entity_id, org, reg_date)
     idp = IdentityProvider.find_or_initialize_by(entity_id: )
 
-    name_node = xpath_at(node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
+    name_node = xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[@xml:lang='en']") ||
+                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[starts-with(@xml:lang, 'en')]")
     name = name_node.content.strip if name_node
 
     idp.update!(name: , organization: org)
@@ -80,7 +84,8 @@ class UpdateFromSAMLMetadata
   def process_sp(node, entity_id, org, reg_date)
     sp = ServiceProvider.find_or_initialize_by(entity_id: )
 
-    name_node = xpath_at(node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
+    name_node = xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[@xml:lang='en']") ||
+                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[starts-with(@xml:lang, 'en')]")
     name = name_node.content.strip if name_node
 
     sp.update!(name: , organization: org)

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -128,7 +128,7 @@ class UpdateFromSAMLMetadata
   end
 
   def activate_object(obj, date)
-    obj.activations.find_or_initialize_by({}).update!(activated_at: date)
+    obj.activations.find_or_initialize_by({}).update!(activated_at: date, deactivated_at: nil)
   end
 
   def source

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -146,8 +146,11 @@ class UpdateFromSAMLMetadata
 
   def org_identifier_from_name(name)
     # Generate a valid identifier for an organisation given the OrganisationName (domain)
-    digest = OpenSSL::Digest.new('SHA256').digest("tuakiri:subscriber:#{name}")
-    Base64.urlsafe_encode64(digest, padding: false)
+    # This identifier may get replaced with an identifier from Federation Registry
+    # To make it easier to identify these temporary identifiers, do not hash them.
+    # To fit into the permitted format (URLsafe Base64), substitute "." in domain name with "_"
+    sanitised_name = name.tr('.', '_')
+    "metadata_#{sanitised_name}"
   end
 
   def clean

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -45,19 +45,19 @@ class UpdateFromSAMLMetadata
 
   # rubocop:disable Metrics/MethodLength
   def process_org(node)
-    org_id_node = xpath_at(node, './md:OrganizationName')
+    org_domain_node = xpath_at(node, './md:OrganizationName')
     org_name_node = xpath_at(node, "./md:OrganizationDisplayName[@xml:lang='en']") ||
                     xpath_at(node, "./md:OrganizationDisplayName[starts-with(@xml:lang, 'en')]")
 
-    return nil unless org_id_node && org_name_node
+    return nil unless org_domain_node && org_name_node
 
-    org_id = org_id_node.content.strip
+    org_domain = org_domain_node.content.strip
     org_name = org_name_node.content.strip
 
-    org = Organization.find_or_initialize_by(domain: org_id)
+    org = Organization.find_or_initialize_by(domain: org_domain)
     org_attrs = { name: org_name }
 
-    org_attrs[:identifier] = org_identifier(org_id) if org.id.nil?
+    org_attrs[:identifier] = org_identifier_from_name(org_domain) if org.id.nil?
 
     org.update!(org_attrs)
 
@@ -144,7 +144,7 @@ class UpdateFromSAMLMetadata
     Rails.application.config.reporting_service.saml_metadata
   end
 
-  def org_identifier(name)
+  def org_identifier_from_name(name)
     # Generate a valid identifier for an organisation given the OrganisationName (domain)
     digest = OpenSSL::Digest.new('SHA256').digest("tuakiri:subscriber:#{name}")
     Base64.urlsafe_encode64(digest, padding: false)

--- a/app/jobs/update_from_saml_metadata.rb
+++ b/app/jobs/update_from_saml_metadata.rb
@@ -47,7 +47,8 @@ class UpdateFromSAMLMetadata
   def process_org(node)
     org_domain_node = xpath_at(node, './md:OrganizationName')
     org_name_node = xpath_at(node, "./md:OrganizationDisplayName[@xml:lang='en']") ||
-                    xpath_at(node, "./md:OrganizationDisplayName[starts-with(@xml:lang, 'en')]")
+                    xpath_at(node, "./md:OrganizationDisplayName[starts-with(@xml:lang, 'en')]") ||
+                    xpath_at(node, "./md:OrganizationDisplayName")
 
     return nil unless org_domain_node && org_name_node
 
@@ -72,8 +73,9 @@ class UpdateFromSAMLMetadata
     idp = IdentityProvider.find_or_initialize_by(entity_id: )
 
     name_node = xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[@xml:lang='en']") ||
-                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[starts-with(@xml:lang, 'en')]")
-    name = name_node.content.strip if name_node
+                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[starts-with(@xml:lang, 'en')]") ||
+                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName")
+    name = name_node ? name_node.content.strip : entity_id
 
     idp.update!(name: , organization: org)
 
@@ -88,8 +90,9 @@ class UpdateFromSAMLMetadata
     sp = ServiceProvider.find_or_initialize_by(entity_id: )
 
     name_node = xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[@xml:lang='en']") ||
-                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[starts-with(@xml:lang, 'en')]")
-    name = name_node.content.strip if name_node
+                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName[starts-with(@xml:lang, 'en')]") ||
+                xpath_at(node, "./md:Extensions/mdui:UIInfo/mdui:DisplayName")
+    name = name_node ? name_node.content.strip : entity_id
 
     sp.update!(name: , organization: org)
 

--- a/app/jobs/update_from_saml_service.rb
+++ b/app/jobs/update_from_saml_service.rb
@@ -13,8 +13,9 @@ class UpdateFromSAMLService
     @service_providers = []
     @identity_providers = []
 
+    doc = document(source, metadata_cert)
     ActiveRecord::Base.transaction do
-      document(source, metadata_cert).xpath('//md:EntityDescriptor', SAML_NAMESPACES).each do |node|
+      doc.xpath('//md:EntityDescriptor', SAML_NAMESPACES).each do |node|
         process_entity(node)
       end
 

--- a/app/jobs/update_from_saml_service.rb
+++ b/app/jobs/update_from_saml_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable Metrics/ClassLength
 
 require 'net/http'
 
@@ -159,3 +160,4 @@ class UpdateFromSAMLService
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/jobs/update_from_saml_service.rb
+++ b/app/jobs/update_from_saml_service.rb
@@ -131,8 +131,8 @@ class UpdateFromSAMLService
   end
 
   def metadata_cert
-    cert = configuration[:metadata_cert]
-    OpenSSL::X509::Certificate.new(cert) if cert
+    cert_path = configuration[:metadata_cert_path]
+    OpenSSL::X509::Certificate.new(File.read(cert_path)) if cert_path
   end
 
   def configuration

--- a/app/jobs/update_from_saml_service.rb
+++ b/app/jobs/update_from_saml_service.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'metadata/schema'
+require 'net/http'
+
+class UpdateFromSAMLService
+  SAML_NAMESPACES = {
+    'xmlns' => 'urn:oasis:names:tc:SAML:2.0:metadata',
+    'xmlns:md' => 'urn:oasis:names:tc:SAML:2.0:metadata',
+    'xmlns:saml' => 'urn:oasis:names:tc:SAML:2.0:assertion',
+    'xmlns:idpdisc' => 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol',
+    'xmlns:mdrpi' => 'urn:oasis:names:tc:SAML:metadata:rpi',
+    'xmlns:mdui' => 'urn:oasis:names:tc:SAML:metadata:ui',
+    'xmlns:mdattr' => 'urn:oasis:names:tc:SAML:metadata:attribute',
+    'xmlns:shibmd' => 'urn:mace:shibboleth:metadata:1.0',
+    'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
+    'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+    'xmlns:fed' => 'http://docs.oasis-open.org/wsfed/federation/200706',
+    'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706',
+    'xmlns:remd' => 'http://refeds.org/metadata'
+  }.freeze
+
+  def self.perform
+    new.perform
+  end
+
+  def perform
+    @organizations = {}
+    @service_providers = []
+    @service_provider_attributes = []
+    @identity_providers = []
+    @identity_provider_attributes = []
+
+    ActiveRecord::Base.transaction do
+      document.xpath("//md:EntityDescriptor", SAML_NAMESPACES).each do |node|
+        process_entity(node)
+      end
+
+      clean
+    end
+
+    nil
+  end
+
+  def process_entity(node)
+    entity_id = node.attributes["entityID"].value
+
+    org_node = xpath_at(node, "./md:Organization")
+    return if org_node.nil?
+
+    org = process_org(org_node)
+    return if org.nil?
+
+    reg_info_node = xpath_at(node, "./md:Extensions/mdrpi:RegistrationInfo")
+    reg_date = nil
+    if reg_info_node then
+      reg_instant_attr = reg_info_node.attributes["registrationInstant"]
+      reg_date = reg_instant_attr.value if reg_instant_attr
+    end
+
+    idp_node = xpath_at(node, "./md:IDPSSODescriptor")
+    idp = process_idp(idp_node, entity_id, org) unless idp_node.nil?
+    @identity_providers.append(idp) if idp
+
+    sp_node = xpath_at(node, "./md:SPSSODescriptor")
+    sp = process_sp(sp_node, entity_id, org) unless sp_node.nil?
+    @service_providers.append(sp) if sp
+
+    if reg_date then
+      activate_object(idp, reg_date) if idp
+      activate_object(sp, reg_date) if sp
+    end
+  end
+
+  def process_org(node)
+    org_id_node = xpath_at(node, "./md:OrganizationName")
+    return nil if org_id_node.nil?
+    org_name_node = xpath_at(node, "./md:OrganizationDisplayName")
+    return nil if org_name_node.nil?
+
+    org_id = org_id_node.content.strip
+    org_name = org_name_node.content.strip
+
+    org = Organization.find_or_initialize_by(domain: org_id)
+    org_attrs = { name: org_name }
+    if org.id.nil? then
+      org_attrs[:identifier] = org_identifier(org_id)
+    end
+    org.update!(org_attrs)
+
+    @organizations[org.id] = org
+
+    org
+  end
+
+  def process_idp(node, entity_id, org)
+    idp = IdentityProvider.find_or_initialize_by(entity_id: entity_id)
+
+    name_node = xpath_at(node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
+    name = name_node.content.strip if name_node
+
+    idp.update!(name: name, organization: org)
+
+    xpath(node, './saml:Attribute').each do |attr|
+      attr_name = attr.attributes["FriendlyName"].value
+      attribute = SAMLAttribute.find_by(name: attr_name)
+      break if attribute.nil?
+
+      assoc = idp.identity_provider_saml_attributes.find_or_initialize_by(saml_attribute_id: attribute.id)
+      assoc.save
+
+      @identity_provider_attributes.append(assoc)
+    end
+
+    idp
+  end
+
+  def process_sp(node, entity_id, org)
+    sp = ServiceProvider.find_or_initialize_by(entity_id: entity_id)
+
+    name_node = xpath_at(node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
+    name = name_node.content.strip if name_node
+
+    sp.update!(name: name, organization: org)
+
+    xpath(node, './md:AttributeConsumingService/md:RequestedAttribute').each do |attr|
+      attr_name = attr.attributes["FriendlyName"].value
+      attribute = SAMLAttribute.find_by(name: attr_name)
+      break if attribute.nil?
+
+      assoc = sp.service_provider_saml_attributes.find_or_initialize_by(saml_attribute_id: attribute.id)
+
+      is_req_attr = attr.attributes["isRequired"]
+      is_req = is_req_attr.nil? ? false : is_req_attr.value == "true"
+
+      assoc.update!(optional: !is_req)
+      @service_provider_attributes.push(assoc)
+    end
+
+    sp
+  end
+
+  def activate_object(obj, date)
+    obj.activations.find_or_initialize_by({}).update!(activated_at: date)
+  end
+
+  def document
+    doc = Nokogiri::XML.parse(retrieve(source))
+
+    saml_md_urn = 'urn:oasis:names:tc:SAML:2.0:metadata'
+    root = doc.root
+
+    return doc if root.namespaces.key(saml_md_urn) == 'xmlns'
+
+    prev_prefix = doc.root.namespace.prefix
+    doc.root.default_namespace = saml_md_urn
+    new_doc_markup = doc.canonicalize.gsub(%r{([<|/])(#{prev_prefix}:)}, '\1')
+
+    Nokogiri::XML.parse(new_doc_markup)
+  end
+
+  def retrieve(source_url)
+    url = URI.parse(source_url)
+    response = perform_http_client_request(url)
+
+    return response.body if response.is_a?(Net::HTTPSuccess)
+
+    raise("Unable to retrieve metadata from #{source_url} (#{response.code} #{response.message})")
+  end
+
+  def perform_http_client_request(url)
+    request = Net::HTTP::Get.new(url)
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = (url.scheme == 'https')
+    http.read_timeout = 600
+    request['Accept'] = "application/samlmetadata+xml"
+
+    http.request(request)
+  end
+
+  def source
+    configuration[:metadata_url]
+  end
+
+  def configuration
+    Rails.application.config.reporting_service.saml_service
+  end
+
+  def xpath(node, path)
+    node.xpath(path, SAML_NAMESPACES)
+  end
+
+  def xpath_at(node, path)
+    xpath(node, path)[0]
+  end
+
+  def org_identifier(fr_id)
+    digest = OpenSSL::Digest.new('SHA256').digest("tuakiri:subscriber:#{fr_id}")
+    Base64.urlsafe_encode64(digest, padding: false)
+  end
+
+  def clean
+    # Deactivate IdPs and SPs that we didn't see while processing, but are currently
+    # considered active.
+    idps = IdentityProvider.where.not(id: @identity_providers.map(&:id)).active
+    idps.each do |idp|
+      idp.activations.update_all(deactivated_at: Time::now)
+    end
+
+    sps = ServiceProvider.where.not(id: @service_providers.map(&:id)).active
+    sps.each do |sp|
+      sp.activations.update_all(deactivated_at: Time::now)
+    end
+  end
+end

--- a/app/jobs/update_from_saml_service.rb
+++ b/app/jobs/update_from_saml_service.rb
@@ -3,21 +3,7 @@
 require 'net/http'
 
 class UpdateFromSAMLService
-  SAML_NAMESPACES = {
-    'xmlns' => 'urn:oasis:names:tc:SAML:2.0:metadata',
-    'xmlns:md' => 'urn:oasis:names:tc:SAML:2.0:metadata',
-    'xmlns:saml' => 'urn:oasis:names:tc:SAML:2.0:assertion',
-    'xmlns:idpdisc' => 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol',
-    'xmlns:mdrpi' => 'urn:oasis:names:tc:SAML:metadata:rpi',
-    'xmlns:mdui' => 'urn:oasis:names:tc:SAML:metadata:ui',
-    'xmlns:mdattr' => 'urn:oasis:names:tc:SAML:metadata:attribute',
-    'xmlns:shibmd' => 'urn:mace:shibboleth:metadata:1.0',
-    'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
-    'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-    'xmlns:fed' => 'http://docs.oasis-open.org/wsfed/federation/200706',
-    'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706',
-    'xmlns:remd' => 'http://refeds.org/metadata'
-  }.freeze
+  include GetSAMLMetadata
 
   def self.perform
     new.perform
@@ -28,7 +14,7 @@ class UpdateFromSAMLService
     @identity_providers = []
 
     ActiveRecord::Base.transaction do
-      document.xpath("//md:EntityDescriptor", SAML_NAMESPACES).each do |node|
+      document(source, metadata_cert).xpath('//md:EntityDescriptor', SAML_NAMESPACES).each do |node|
         process_entity(node)
       end
 
@@ -39,158 +25,103 @@ class UpdateFromSAMLService
   end
 
   def process_entity(node)
-    entity_id = node.attributes["entityID"].value
+    entity_id = node.attributes['entityID'].value
 
-    org_node = xpath_at(node, "./md:Organization")
-    return if org_node.nil?
+    org_node = xpath_at(node, './md:Organization')
+    org = process_org(org_node) if org_node
+    return unless org
 
-    org = process_org(org_node)
-    return if org.nil?
+    reg_info_node = xpath_at(node, './md:Extensions/mdrpi:RegistrationInfo')
+    reg_date = attr_val(reg_info_node, 'registrationInstant') if reg_info_node
 
-    reg_info_node = xpath_at(node, "./md:Extensions/mdrpi:RegistrationInfo")
-    reg_date = nil
-    if reg_info_node then
-      reg_instant_attr = reg_info_node.attributes["registrationInstant"]
-      reg_date = reg_instant_attr.value if reg_instant_attr
-    end
+    idp_node = xpath_at(node, './md:IDPSSODescriptor')
+    process_idp(idp_node, entity_id, org, reg_date) if idp_node
 
-    idp_node = xpath_at(node, "./md:IDPSSODescriptor")
-    idp = process_idp(idp_node, entity_id, org) unless idp_node.nil?
-    @identity_providers.append(idp) if idp
-
-    sp_node = xpath_at(node, "./md:SPSSODescriptor")
-    sp = process_sp(sp_node, entity_id, org) unless sp_node.nil?
-    @service_providers.append(sp) if sp
-
-    if reg_date then
-      activate_object(idp, reg_date) if idp
-      activate_object(sp, reg_date) if sp
-    end
+    sp_node = xpath_at(node, './md:SPSSODescriptor')
+    process_sp(sp_node, entity_id, org, reg_date) if sp_node
   end
 
   def process_org(node)
-    org_id_node = xpath_at(node, "./md:OrganizationName")
-    return nil if org_id_node.nil?
-    org_name_node = xpath_at(node, "./md:OrganizationDisplayName")
-    return nil if org_name_node.nil?
+    org_id_node = xpath_at(node, './md:OrganizationName')
+    org_name_node = xpath_at(node, './md:OrganizationDisplayName')
+
+    return nil unless org_id_node && org_name_node
 
     org_id = org_id_node.content.strip
     org_name = org_name_node.content.strip
 
     org = Organization.find_or_initialize_by(domain: org_id)
     org_attrs = { name: org_name }
-    if org.id.nil? then
-      org_attrs[:identifier] = org_identifier(org_id)
-    end
+
+    org_attrs[:identifier] = org_identifier(org_id) if org.id.nil?
+
     org.update!(org_attrs)
 
     org
   end
 
-  def process_idp(node, entity_id, org)
-    idp = IdentityProvider.find_or_initialize_by(entity_id: entity_id)
+  def process_idp(node, entity_id, org, reg_date)
+    idp = IdentityProvider.find_or_initialize_by(entity_id: )
 
     name_node = xpath_at(node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
     name = name_node.content.strip if name_node
 
-    idp.update!(name: name, organization: org)
+    idp.update!(name: , organization: org)
 
     idp_attributes = idp.identity_provider_saml_attributes
+    process_idp_attributes(idp_attributes, node)
 
-    attrs = xpath(node, './saml:Attribute').map do |attr|
-      attr_name = attr.attributes["FriendlyName"].value
-      attribute = SAMLAttribute.find_by(name: attr_name)
-      next if attribute.nil?
-
-      assoc = idp_attributes.find_or_initialize_by(saml_attribute_id: attribute.id)
-      assoc.save
-      assoc
-    end
-
-    # Delete attributes that aren't associated with this IdP any more
-    attrs.compact!
-    idp_attributes.where.not(id: attrs.map(&:id)).destroy_all
-
-    idp
+    @identity_providers.append(idp)
+    activate_object(idp, reg_date)
   end
 
-  def process_sp(node, entity_id, org)
-    sp = ServiceProvider.find_or_initialize_by(entity_id: entity_id)
+  def process_sp(node, entity_id, org, reg_date)
+    sp = ServiceProvider.find_or_initialize_by(entity_id: )
 
     name_node = xpath_at(node, './md:Extensions/mdui:UIInfo/mdui:DisplayName')
     name = name_node.content.strip if name_node
 
-    sp.update!(name: name, organization: org)
+    sp.update!(name: , organization: org)
 
     sp_attributes = sp.service_provider_saml_attributes
-    attrs = xpath(node, './md:AttributeConsumingService/md:RequestedAttribute').map do |attr|
-      attr_name = attr.attributes["FriendlyName"].value
+    process_sp_attributes(sp_attributes, node)
+
+    @service_providers.append(sp)
+    activate_object(sp, reg_date)
+  end
+
+  def process_idp_attributes(scope, node)
+    nodes = xpath(node, './saml:Attribute')
+    process_attributes(scope, nodes) do |_, assoc|
+      assoc.save
+    end
+  end
+
+  def process_sp_attributes(scope, node)
+    nodes = xpath(node, './md:AttributeConsumingService/md:RequestedAttribute')
+    process_attributes(scope, nodes) do |attr, assoc|
+      is_req = attr_val(attr, 'isRequired') == 'true'
+      assoc.update(optional: !is_req)
+    end
+  end
+
+  def process_attributes(scope, nodes)
+    attrs = nodes.map do |attr|
+      attr_name = attr_val(attr, 'FriendlyName')
       attribute = SAMLAttribute.find_by(name: attr_name)
-      next if attribute.nil?
+      next unless attribute
 
-      assoc = sp_attributes.find_or_initialize_by(saml_attribute_id: attribute.id)
+      assoc = scope.find_or_initialize_by(saml_attribute_id: attribute.id)
 
-      is_req_attr = attr.attributes["isRequired"]
-      is_req = is_req_attr.nil? ? false : is_req_attr.value == "true"
-
-      assoc.update!(optional: !is_req)
-      assoc
+      assoc if yield attr, assoc
     end
 
-    # Delete attributes that aren't associated with this SP any more
-    attrs.compact!
-    sp_attributes.where.not(id: attrs.map(&:id)).destroy_all
-
-    sp
+    # Delete attributes that aren't associated with this IdP/SP any more
+    scope.where.not(id: attrs.compact.map(&:id)).destroy_all
   end
 
   def activate_object(obj, date)
     obj.activations.find_or_initialize_by({}).update!(activated_at: date)
-  end
-
-  def document
-    doc = Nokogiri::XML.parse(retrieve(source))
-
-    verify_signature(doc)
-
-    saml_md_urn = 'urn:oasis:names:tc:SAML:2.0:metadata'
-    root = doc.root
-
-    return doc if root.namespaces.key(saml_md_urn) == 'xmlns'
-
-    prev_prefix = doc.root.namespace.prefix
-    doc.root.default_namespace = saml_md_urn
-    new_doc_markup = doc.canonicalize.gsub(%r{([<|/])(#{prev_prefix}:)}, '\1')
-
-    Nokogiri::XML.parse(new_doc_markup)
-  end
-
-  def retrieve(source_url)
-    url = URI.parse(source_url)
-    response = perform_http_client_request(url)
-
-    return response.body if response.is_a?(Net::HTTPSuccess)
-
-    raise("Unable to retrieve metadata from #{source_url} (#{response.code} #{response.message})")
-  end
-
-  def perform_http_client_request(url)
-    request = Net::HTTP::Get.new(url)
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = (url.scheme == 'https')
-    http.read_timeout = 600
-    request['Accept'] = "application/samlmetadata+xml"
-
-    http.request(request)
-  end
-
-  def verify_signature(doc)
-    cert = metadata_cert
-    return if cert.nil?
-
-    return if Xmldsig::SignedDocument.new(doc).validate(cert)
-
-    raise("Invalid signature for metadata from #{source}")
   end
 
   def source
@@ -206,14 +137,6 @@ class UpdateFromSAMLService
     Rails.application.config.reporting_service.saml_service
   end
 
-  def xpath(node, path)
-    node.xpath(path, SAML_NAMESPACES)
-  end
-
-  def xpath_at(node, path)
-    xpath(node, path)[0]
-  end
-
   def org_identifier(name)
     # Generate a valid identifier for an organisation given the OrganisationName (domain)
     digest = OpenSSL::Digest.new('SHA256').digest("tuakiri:subscriber:#{name}")
@@ -223,14 +146,15 @@ class UpdateFromSAMLService
   def clean
     # Deactivate IdPs and SPs that we didn't see while processing, but are currently
     # considered active.
-    idps = IdentityProvider.where.not(id: @identity_providers.map(&:id)).active
-    idps.each do |idp|
-      idp.activations.update_all(deactivated_at: Time::now)
-    end
+    clean_entities(IdentityProvider.where.not(id: @identity_providers.map(&:id)).active)
+    clean_entities(ServiceProvider.where.not(id: @service_providers.map(&:id)).active)
+  end
 
-    sps = ServiceProvider.where.not(id: @service_providers.map(&:id)).active
-    sps.each do |sp|
-      sp.activations.update_all(deactivated_at: Time::now)
+  def clean_entities(entities)
+    entities.each do |e|
+      e.activations.each do |a|
+        a.update(deactivated_at: Time.current)
+      end
     end
   end
 end

--- a/bin/saml_update.rb
+++ b/bin/saml_update.rb
@@ -5,7 +5,7 @@ require_relative '../config/environment'
 
 class SamlUpdateCLI
   def self.perform
-    UpdateFromSAMLService.perform
+    UpdateFromSAMLMetadata.perform
   end
 end
 

--- a/bin/saml_update.rb
+++ b/bin/saml_update.rb
@@ -5,7 +5,7 @@ require_relative '../config/environment'
 
 class SamlUpdateCLI
   def self.perform
-    UpdateFromSamlService.perform
+    UpdateFromSAMLService.perform
   end
 end
 

--- a/bin/saml_update.rb
+++ b/bin/saml_update.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+
+class SamlUpdateCLI
+  def self.perform
+    UpdateFromSamlService.perform
+  end
+end
+
+SamlUpdateCLI.perform(*ARGV) if $PROGRAM_NAME == __FILE__

--- a/config/reporting_service_configuration.rb
+++ b/config/reporting_service_configuration.rb
@@ -11,7 +11,7 @@ module ReportingService
 
   class ConfigurationGenerator
     def build_configuration
-      base_config.merge(admins_config, redis, federation_registry, rapid_connect)
+      base_config.merge(admins_config, redis, federation_registry, rapid_connect, saml_metadata)
     end
 
     private
@@ -89,6 +89,15 @@ module ReportingService
             host: ENV.fetch('FEDERATION_REGISTRY_DB_HOST', ''),
             port: ENV.fetch('FEDERATION_REGISTRY_DB_PORT', '3306')
           }
+        }
+      }
+    end
+
+    def saml_metadata
+      {
+        saml_metadata: {
+          metadata_url: ENV.fetch('SAML_METADATA_URL', nil),
+          metadata_cert_path: ENV.fetch('SAML_METADATA_CERT_PATH', nil)
         }
       }
     end

--- a/db/migrate/20240506132318_add_domain_to_organisation.rb
+++ b/db/migrate/20240506132318_add_domain_to_organisation.rb
@@ -1,0 +1,6 @@
+class AddDomainToOrganisation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :domain, :string
+    add_index :organizations, :domain, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_15_042123) do
+ActiveRecord::Schema.define(version: 2024_05_06_132318) do
 
   create_table "activations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+
     t.string "federation_object_type", null: false
     t.integer "federation_object_id", null: false
     t.datetime "activated_at", null: false
@@ -136,6 +137,8 @@ ActiveRecord::Schema.define(version: 2024_01_15_042123) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "domain"
+    t.index ["domain"], name: "index_organizations_on_domain", unique: true
     t.index ["identifier"], name: "index_organizations_on_identifier", unique: true
   end
 


### PR DESCRIPTION
Some IdPs/SPs are added directly to the SAML service. The reporting service sources it's information from the federation registry, meaning it doesn't see those entities. This change pulls metadata from the SAML service to augment the data from the federation registry.