### PR TITLE
new: Fix CVE-2024-21539

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "eslint-plugin-yml": "1.14.0",
     "prettier": "3.3.3"
   },
+  "resolutions": {
+    "@eslint/plugin-kit": "^0.2.3"
+  },
   "scripts": {
     "lint": "eslint . --quiet"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.4.tgz#9e69f8bb4031e11df79e03db09f9dbbae1740843"
   integrity sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==
 
-"@eslint/plugin-kit@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz#8712dccae365d24e9eeecb7b346f85e750ba343d"
-  integrity sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==
+"@eslint/plugin-kit@^0.2.0", "@eslint/plugin-kit@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz#812980a6a41ecf3a8341719f92a6d1e784a2e0e8"
+  integrity sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==
   dependencies:
     levn "^0.4.1"
 


### PR DESCRIPTION
This change forces the app to use plugin-kit version 0.2.3 or higher, which should fix https://github.com/REANNZ/reporting-service/security/dependabot/73 .