### PR TITLE
fix: MDToolAPI: handle null memberSince

### DIFF
--- a/app/jobs/concerns/query_api.rb
+++ b/app/jobs/concerns/query_api.rb
@@ -10,12 +10,14 @@ module QueryAPI
 
   def api_org_to_fr_org(o)
     # Make the object look like it was returned by FR export API
+    # As MDTool can return nil memberSince, fudge current time as activation time for compatibility
+    member_since = o[:memberSince] ? DateTime.parse(o[:memberSince]) : Time.now.utc
     {
       id: o[:id],
       domain: o[:organizationInfoData][:en][:OrganizationName],
       display_name: o[:organizationInfoData][:en][:OrganizationDisplayName],
-      created_at: DateTime.parse(o[:memberSince]),
-      updated_at: o[:active] ? DateTime.parse(o[:memberSince]) : DateTime.parse(o[:notMemberAfter]),
+      created_at: member_since,
+      updated_at: o[:active] ? member_since : DateTime.parse(o[:notMemberAfter]),
       functioning: o[:active]
     }
   end


### PR DESCRIPTION
As MDTool can return null memberSince, fudge current time as activation time for compatibility.

The activation time is only used for the Federation Growth Report.

Using current time will make it appear as "just registered" organisation, which is the best we can do when memberSince is not provided.